### PR TITLE
scappy: pin to last supported version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-scapy
+scapy<=2.4.4


### PR DESCRIPTION
Hi there,

the last version seems to be no longer supported,

`ImportError: cannot import name 'AnsweringMachine' from partially initialized module 'scapy.ansmachine' (most likely due to a circular import) (x/scapy/ansmachine.py)`